### PR TITLE
feat: cafe entity 수정 및 create, read 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.1.0'
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'
+	testRuntimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.1.0'
+	implementation 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'mysql:mysql-connector-java'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/controller/NoticeController.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/controller/NoticeController.java
@@ -1,0 +1,16 @@
+package kr.ac.cnu.swacademy.cagong.controller;
+
+import kr.ac.cnu.swacademy.cagong.dto.NoticeSaveRequestDto;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class NoticeController {
+
+    @GetMapping("/notice/save")
+    public String postSave(Model model) {
+        model.addAttribute("saveForm", new NoticeSaveRequestDto());
+        return "notice/saveForm";
+    }
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/controller/api/NoticeApiController.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/controller/api/NoticeApiController.java
@@ -1,0 +1,21 @@
+package kr.ac.cnu.swacademy.cagong.controller.api;
+
+import kr.ac.cnu.swacademy.cagong.dto.NoticeSaveRequestDto;
+import kr.ac.cnu.swacademy.cagong.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RestController
+public class NoticeApiController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping("/api/v1/notice")
+    public long save(@RequestBody NoticeSaveRequestDto requestDto) {
+        return noticeService.save(requestDto);
+    }
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/dto/NoticeSaveRequestDto.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/dto/NoticeSaveRequestDto.java
@@ -1,0 +1,26 @@
+package kr.ac.cnu.swacademy.cagong.dto;
+
+import kr.ac.cnu.swacademy.cagong.entity.Notice;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeSaveRequestDto {
+    private String title;
+    private String content;
+
+    @Builder
+    public NoticeSaveRequestDto(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public Notice toEntity() {
+        return Notice.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
@@ -4,9 +4,9 @@ import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @NoArgsConstructor
 @Table(name="cafes")
@@ -28,18 +28,43 @@ public class Cafe extends BaseTimeEntity {
     @Column(length = 45)
     private String address;
 
+    @NotNull
+    private Double longitude;
+
+    @NotNull
+    private Double latitude;
+
+    private Double averagePrice;
+
+    /**
+     * 네이버에서의 평점
+     */
+    private Double averageScoreInNaver;
+
+    /**
+     * 네이버에서 좌석이 좋아요를 선택한 사용자의 수
+     */
+    private Integer seatSelectionCountInNaver;
+
+    /**
+     * 네이버에서 집중하기 좋아요를 선택한 사용자의 수
+     */
+    private Integer concentrationSelectionCountInNaver;
+
     @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
 
     @Builder
-    public Cafe(String name, String address) {
+    public Cafe(String name, String address, Double averagePrice, Double longitude, Double latitude, Double averageScoreInNaver, Integer seatSelectionCountInNaver, Integer concentrationSelectionCountInNaver) {
         this.name = name;
         this.address = address;
+        this.averagePrice = averagePrice;
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.averageScoreInNaver = averageScoreInNaver;
+        this.seatSelectionCountInNaver = seatSelectionCountInNaver;
+        this.concentrationSelectionCountInNaver = concentrationSelectionCountInNaver;
     }
-
-    // 나중에 구현
-//    private Double longitude;
-//    private Double latitude;
 
     public void addReview(Review review) {
         review.setCafe(this);

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
@@ -1,13 +1,19 @@
 package kr.ac.cnu.swacademy.cagong.entity;
 
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @NoArgsConstructor
 @Table(name="cafes")
 @Entity
+@Setter
+@Getter
+@ToString
 public class Cafe extends BaseTimeEntity {
 
     @Id
@@ -23,6 +29,15 @@ public class Cafe extends BaseTimeEntity {
     @Column(length = 45)
     private String address;
 
-    private int mapX;
-    private int mapY;
+    @Setter(AccessLevel.NONE)
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
+// 나중에 구현
+//    private Double longitude;
+//    private Double latitude;
+
+    public void addReview(Review review) {
+        review.setCafe(this);
+    }
 }

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Cafe.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 @NoArgsConstructor
 @Table(name="cafes")
 @Entity
-@Setter
 @Getter
 @ToString
 public class Cafe extends BaseTimeEntity {
@@ -29,11 +28,16 @@ public class Cafe extends BaseTimeEntity {
     @Column(length = 45)
     private String address;
 
-    @Setter(AccessLevel.NONE)
     @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
 
-// 나중에 구현
+    @Builder
+    public Cafe(String name, String address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    // 나중에 구현
 //    private Double longitude;
 //    private Double latitude;
 

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Notice.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Notice.java
@@ -1,0 +1,35 @@
+package kr.ac.cnu.swacademy.cagong.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Notice extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "notice_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(length = 45)
+    private String title;
+
+    @Lob
+    @NotNull
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Review.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Review.java
@@ -1,7 +1,6 @@
 package kr.ac.cnu.swacademy.cagong.entity;
 
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -12,7 +11,6 @@ import java.util.Objects;
 @NoArgsConstructor
 @Table(name="reviews")
 @Entity
-@Setter
 public class Review extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Review.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/entity/Review.java
@@ -1,15 +1,18 @@
 package kr.ac.cnu.swacademy.cagong.entity;
 
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Objects;
 
 @NoArgsConstructor
 @Table(name="reviews")
 @Entity
+@Setter
 public class Review extends BaseTimeEntity {
 
     @Id
@@ -38,4 +41,13 @@ public class Review extends BaseTimeEntity {
     private int seat;
     @NotNull
     private int concentration;
+
+    public void setCafe(Cafe cafe) {
+        if (Objects.nonNull(this.cafe)) {
+            this.cafe.getReviews().remove(this);
+        }
+
+        this.cafe = cafe;
+        cafe.getReviews().add(this);
+    }
 }

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepository.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepository.java
@@ -1,0 +1,7 @@
+package kr.ac.cnu.swacademy.cagong.repository;
+
+import kr.ac.cnu.swacademy.cagong.entity.Cafe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CafeRepository extends JpaRepository<Cafe, Long> {
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepository.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepository.java
@@ -3,5 +3,9 @@ package kr.ac.cnu.swacademy.cagong.repository;
 import kr.ac.cnu.swacademy.cagong.entity.Cafe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
+
+    Optional<Cafe> findByName(String name);
 }

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/repository/NoticeRepository.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package kr.ac.cnu.swacademy.cagong.repository;
+
+import kr.ac.cnu.swacademy.cagong.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/kr/ac/cnu/swacademy/cagong/service/NoticeService.java
+++ b/src/main/java/kr/ac/cnu/swacademy/cagong/service/NoticeService.java
@@ -1,0 +1,19 @@
+package kr.ac.cnu.swacademy.cagong.service;
+
+import kr.ac.cnu.swacademy.cagong.dto.NoticeSaveRequestDto;
+import kr.ac.cnu.swacademy.cagong.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Service
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public Long save(NoticeSaveRequestDto requestDto) {
+        return noticeRepository.save(requestDto.toEntity()).getId();
+    }
+}

--- a/src/main/resources/static/js/notice.js
+++ b/src/main/resources/static/js/notice.js
@@ -1,0 +1,28 @@
+let main = {
+    init : function () {
+        let _this = this;
+        $('#btn-save').on('click', function () {
+            _this.save();
+        });
+    },
+    save : function () {
+        let data = {
+            title: $('#title').val(),
+            content: $('#content').val()
+        };
+
+        $.ajax({
+            type: 'POST',
+            url: '/api/v1/notice',
+            dataType: 'json',
+            contentType:'application/json; charset=utf-8',
+            data: JSON.stringify(data)
+        }).done(function() {
+            alert('글이 등록되었습니다.');
+        }).fail(function (error) {
+            alert(JSON.stringify(error));
+        });
+    }
+};
+
+main.init();

--- a/src/main/resources/templates/notice/saveForm.html
+++ b/src/main/resources/templates/notice/saveForm.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>cagong</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <style>
+        main {
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100vh;
+            max-height: 100vh;
+            overflow-x: auto;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 280px;">
+        <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none">
+            <svg class="bi me-2" width="40" height="32">
+                <use xlink:href="#bootstrap"></use>
+            </svg>
+            <span class="fs-4">CaGong</span>
+        </a>
+        <hr>
+        <ul class="nav nav-pills flex-column mb-auto">
+            <li class="nav-item">
+                <a href="#" class="nav-link link-dark">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#home"></use>
+                    </svg>
+                    마이페이지
+                </a>
+            </li>
+            <li>
+                <a href="#" class="nav-link active" aria-current="page">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#speedometer2"></use>
+                    </svg>
+                    공지사항
+                </a>
+            </li>
+            <li>
+                <a href="#" class="nav-link link-dark">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#table"></use>
+                    </svg>
+                    Q&A
+                </a>
+            </li>
+        </ul>
+        <hr>
+        <div class="dropdown">
+            <a href="#" class="d-flex align-items-center link-dark text-decoration-none dropdown-toggle"
+               id="dropdownUser2"
+               data-bs-toggle="dropdown" aria-expanded="false">
+                <img src="https://github.com/mdo.png" alt="" width="32" height="32" class="rounded-circle me-2">
+                <strong>mdo</strong>
+            </a>
+            <ul class="dropdown-menu text-small shadow" aria-labelledby="dropdownUser2">
+                <li><a class="dropdown-item" href="#">New project...</a></li>
+                <li><a class="dropdown-item" href="#">Settings</a></li>
+                <li><a class="dropdown-item" href="#">Profile</a></li>
+                <li>
+                    <hr class="dropdown-divider">
+                </li>
+                <li><a class="dropdown-item" href="#">Sign out</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="b-example-divider"></div>
+    <div class="container mt-3 " style="width: 800px">
+        <h2>공지사항</h2>
+        <div class="mb-3">
+            <label for="title" class="form-label"></label>
+            <input type="text" class="form-control" th:field="${saveForm.title}" id="title"
+                   placeholder="제목을 입력해주세요">
+        </div>
+        <div class="mb-3">
+            <label for="content" class="form-label"></label>
+            <textarea class="form-control" th:field="${saveForm.content}" id="content" rows="3"
+                      style="height: 500px"
+                      placeholder="내용을 입력해주세요"></textarea>
+        </div>
+        <button type="button" id="btn-save" class="btn btn-primary">저장</button>
+    </div>
+    <script type="text/javascript" th:src="@{/js/notice.js}"></script>
+</main>
+</body>
+</html>

--- a/src/test/java/kr/ac/cnu/swacademy/cagong/controller/api/NoticeApiControllerTest.java
+++ b/src/test/java/kr/ac/cnu/swacademy/cagong/controller/api/NoticeApiControllerTest.java
@@ -1,0 +1,73 @@
+package kr.ac.cnu.swacademy.cagong.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.ac.cnu.swacademy.cagong.dto.NoticeSaveRequestDto;
+import kr.ac.cnu.swacademy.cagong.entity.Notice;
+import kr.ac.cnu.swacademy.cagong.repository.NoticeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@DisplayName("View 컨트롤러 - 공지사항")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class NoticeApiControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private NoticeRepository noticeRepository;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    public void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @Test
+    void Notice_등록된다() throws Exception {
+        //given
+        String title = "title";
+        String content = "content";
+
+        NoticeSaveRequestDto requestDto = NoticeSaveRequestDto.builder()
+                .title(title)
+                .content(content)
+                .build();
+        String url = "http://localhost:" + port + "/api/v1/notice";
+
+        //when
+        mvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(requestDto)))
+                .andExpect(status().isOk());
+
+        //then
+        List<Notice> NoticeList = noticeRepository.findAll();
+        assertThat(NoticeList.get(0).getTitle()).isEqualTo(title);
+        assertThat(NoticeList.get(0).getContent()).isEqualTo(content);
+    }
+}

--- a/src/test/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepositoryTest.java
+++ b/src/test/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepositoryTest.java
@@ -1,7 +1,6 @@
 package kr.ac.cnu.swacademy.cagong.repository;
 
 import kr.ac.cnu.swacademy.cagong.entity.Cafe;
-import kr.ac.cnu.swacademy.cagong.entity.Review;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,17 +23,14 @@ class CafeRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        Review review = new Review();
-        review.setContent("이집 커피 잘하네.");
-        review.setImageUrl("");
-        review.setClean(1);
-        review.setConcentration(2);
-        review.setSeat(3);
+        Random randomGenerator = new Random();
 
-        cafe = new Cafe();
-        cafe.setName("스타벅스 충남대 정문점");
-        cafe.setAddress("대전 유성구 대학로 82");
-        cafe.addReview(review);
+        cafe = Cafe.builder()
+                .name("스타벅스 충남대 정문점")
+                .address("대전 유성구 대학로 82")
+                .latitude(randomGenerator.nextDouble())
+                .longitude(randomGenerator.nextDouble())
+                .build();
 
         cafeRepository.save(cafe);
     }
@@ -44,11 +42,19 @@ class CafeRepositoryTest {
 
     @Test
     void 카페리스트_조회하기() {
-        //when
         List<Cafe> cafes = cafeRepository.findAll();
 
-        //then
         assertThat(cafes).hasSize(1);
-        assertThat(cafes.get(0).getName()).isEqualTo(cafe.getName());
+        assertThat(cafes.get(0).getId()).isEqualTo(cafe.getId());
     }
+
+    @Test
+    void 카페이름으로_조회하기() {
+        Optional<Cafe> givenCafe = cafeRepository.findByName(cafe.getName());
+
+        assertThat(givenCafe).isNotEmpty();
+        assertThat(givenCafe.get().getName()).isEqualTo(cafe.getName());
+    }
+
+
 }

--- a/src/test/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepositoryTest.java
+++ b/src/test/java/kr/ac/cnu/swacademy/cagong/repository/CafeRepositoryTest.java
@@ -1,0 +1,54 @@
+package kr.ac.cnu.swacademy.cagong.repository;
+
+import kr.ac.cnu.swacademy.cagong.entity.Cafe;
+import kr.ac.cnu.swacademy.cagong.entity.Review;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CafeRepositoryTest {
+
+    @Autowired
+    CafeRepository cafeRepository;
+
+    private Cafe cafe;
+
+    @BeforeEach
+    void setUp() {
+        Review review = new Review();
+        review.setContent("이집 커피 잘하네.");
+        review.setImageUrl("");
+        review.setClean(1);
+        review.setConcentration(2);
+        review.setSeat(3);
+
+        cafe = new Cafe();
+        cafe.setName("스타벅스 충남대 정문점");
+        cafe.setAddress("대전 유성구 대학로 82");
+        cafe.addReview(review);
+
+        cafeRepository.save(cafe);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cafeRepository.deleteAll();
+    }
+
+    @Test
+    void 카페리스트_조회하기() {
+        //when
+        List<Cafe> cafes = cafeRepository.findAll();
+
+        //then
+        assertThat(cafes).hasSize(1);
+        assertThat(cafes.get(0).getName()).isEqualTo(cafe.getName());
+    }
+}

--- a/src/test/java/kr/ac/cnu/swacademy/cagong/service/NoticeServiceTest.java
+++ b/src/test/java/kr/ac/cnu/swacademy/cagong/service/NoticeServiceTest.java
@@ -1,0 +1,42 @@
+package kr.ac.cnu.swacademy.cagong.service;
+
+import kr.ac.cnu.swacademy.cagong.dto.NoticeSaveRequestDto;
+import kr.ac.cnu.swacademy.cagong.entity.Notice;
+import kr.ac.cnu.swacademy.cagong.repository.NoticeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 공지사항")
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Test
+    void 공지사항_입력() {
+        //given
+        NoticeSaveRequestDto dto = new NoticeSaveRequestDto("제목", "내용");
+        Notice notice = dto.toEntity();
+        given(noticeRepository.save(any(Notice.class))).willReturn(notice);
+
+        //when
+        noticeService.save(dto);
+
+        //then
+        then(noticeRepository).should().save(any(Notice.class));
+
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    open-in-view: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+
+logging.level.org.hibernate.type.descriptor.sql: trace


### PR DESCRIPTION
* Cafe 엔티티 수정
  * AI팀으로부터 전달받을 필드들을 모두 추가함
  * Cafe <-> Review 양방향 매핑 연결
 * CafeRepository 생성
   * `findByName()` 추가
  * CafeRepository 테스트
    * 테스트용 DB로 H2사용
    * create, read 테스트